### PR TITLE
Go dep link fixed in bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,14 +24,6 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -e
-            git branch --set-upstream-to=origin/master master
-            git pull --allow-unrelated-histories
-            git push origin master
     - git-clone:
         run_if: true
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -91,7 +91,7 @@ workflows:
             # Check for unhandled errors
             go get -u -v github.com/kisielk/errcheck
             # Go lint
-            go get -u -v golang.org/x/lint/golint 
+            go get -u -v golang.org/x/lint/golint
 
   # ----------------------------------------------------------------
   # --- Utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -91,7 +91,7 @@ workflows:
             # Check for unhandled errors
             go get -u -v github.com/kisielk/errcheck
             # Go lint
-            go get -u -v github.com/golang/lint/golint
+            go get -u -v golang.org/x/lint/golint 
 
   # ----------------------------------------------------------------
   # --- Utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - STEP_VERSION: 0.9.1
-  - SAMPLE_APP_URL: https://github.com/istvankovacs-bitrise/karma_test.git
+  - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-cordova-with-karma-jasmine.git
 
 workflows:
   test:
@@ -30,7 +30,7 @@ workflows:
     - path::./:
         title: Step Test
         inputs:
-        - browsers: Chrome
+        - browsers: Safari
 
   go-tests:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,16 +24,9 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
-    - git-clone:
-        run_if: true
+    - script:
         inputs:
-        - repository_url: $SAMPLE_APP_URL
-        - clone_into_dir: ./
-        - commit: ""
-        - tag: ""
-        - branch: "master"
-        - pull_request_id: ""
-        - clone_depth: ""
+          - content: git clone $SAMPLE_APP_URL ./
     - path::./:
         title: Step Test
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - STEP_VERSION: 0.9.1
-  - SAMPLE_APP_URL: https://github.com/istvankovacs-bitrise/karma_test.git
+  - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-cordova-with-karma-jasmine.git
 
 workflows:
   test:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - STEP_VERSION: 0.9.1
-  - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-cordova-with-karma-jasmine.git
+  - SAMPLE_APP_URL: https://github.com/istvankovacs-bitrise/karma_test.git
 
 workflows:
   test:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,6 +24,14 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -e
+            git branch --set-upstream-to=origin/master master
+            git pull --allow-unrelated-histories
+            git push origin master
     - git-clone:
         run_if: true
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,7 +30,7 @@ workflows:
     - path::./:
         title: Step Test
         inputs:
-        - browsers: Safari
+        - browsers: Chrome
 
   go-tests:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - STEP_VERSION: 0.9.1
-  - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-cordova-with-karma-jasmine.git
+  - SAMPLE_APP_URL: https://github.com/istvankovacs-bitrise/karma_test.git
 
 workflows:
   test:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Does not require [version update](https://semver.org/)

### Context

The CI was failing for quite some time, due to a deprecated link used to update a Go dependency.

### Changes

Replaced a deprecated link update a Go dependency.

### Investigation details

Noting to share.
